### PR TITLE
Unit Amount = Total Amount (PR Line)

### DIFF
--- a/hr_advance_detail_from_purchase_request/models/hr_expense.py
+++ b/hr_advance_detail_from_purchase_request/models/hr_expense.py
@@ -42,7 +42,7 @@ class HrExpenseSheet(models.Model):
             {
                 "name": pr.description or _("Employee Advance"),
                 "employee_id": pr.requested_by.employee_id.id,
-                "unit_amount": sum(pr.line_ids.mapped("estimated_cost")),
+                "unit_amount": sum(self.pr_line_ids.mapped("total_amount")),
                 "sheet_id": self.id,
             }
         )
@@ -55,7 +55,7 @@ class HrExpenseSheet(models.Model):
         # Prepare advance_line dict
         advance_line = pr_line._convert_to_write(pr_line._cache)
         advance_line["expense_id"] = advance.id
-        advance_line["unit_amount"] = advance_line["total_amount"]
+        advance_line["unit_amount"] = pr_line.total_amount
         # Make sure only advl_fields is used, to create the advance line.
         advance_line = {k: v for k, v in advance_line.items() if k in advl_fields}
         return advance_line


### PR DESCRIPTION
I found the error when I create expense report with advance type
![Selection_021](https://user-images.githubusercontent.com/24691983/119241190-d7756300-bb7e-11eb-83cf-686f82887423.png)

I just change `unit_amount` pull from `total_amount` in tab `Expense from PR`

Could you review my fix ? @kittiu 